### PR TITLE
Filled out repo information

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/1and1/oneandone-cloudserver-sdk-nodejs/issues"
   },
-  "homepage": "ttps://github.com/1and1/oneandone-cloudserver-sdk-nodejs",
+  "homepage": "https://github.com/1and1/oneandone-cloudserver-sdk-nodejs",
   "directories": {
     "example": "examples"
   },

--- a/package.json
+++ b/package.json
@@ -2,25 +2,16 @@
   "name": "liboneandone",
   "version": "1.2.0",
   "description": "The 1&1 Library for Node and Io",
-  "main": "./lib/index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "author": "alibaz <ali@stackpointcloud.com>",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/temp/temp.git"
+    "url": "https://github.com/1and1/oneandone-cloudserver-sdk-nodejs.git"
   },
-  "author": "alibaz <ali@stackpointcloud.com>",
-  "license": "BSD",
   "bugs": {
-    "url": ""
+    "url": "https://github.com/1and1/oneandone-cloudserver-sdk-nodejs/issues"
   },
-  "homepage": "",
-  "dependencies": {
-    "mocha": "^2.5.3",
-    "request": "^2.74.0"
-  },
-  "devDependencies": {},
+  "homepage": "ttps://github.com/1and1/oneandone-cloudserver-sdk-nodejs",
   "directories": {
     "example": "examples"
   },
@@ -37,5 +28,15 @@
     "libOneAndone",
     "1&1",
     "fs"
-  ]
+  ],
+  "main": "./lib/index.js",
+  "dependencies": {
+    "request": "^2.88.0"
+  },
+  "devDependencies": {
+    "mocha": "^5.2.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  }
 }


### PR DESCRIPTION
## What does it do?

TLDR: It makes it easier for developers to find information about the repo.

Currently, if you run this:

```sh
npm docs liboneandone
# open https://github.com/temp/temp#readme

npm info liboneandone repository
# { type: 'git', url: 'git+https://github.com/temp/temp.git' }
```

This PR fills in the information to point those URLs at your repo and documentation.

Additionally it adds `npm test` script and fixes these two issues: #20 #21

## How to test?

```sh
git clone -b pkg-json-tweaks https://github.com/tcrowe/oneandone-cloudserver-sdk-nodejs.git liboneandone
cd liboneandone
npm install
npm test
```

I'm not sure how you guys get the tests to complete but you can see if this works. Maybe there is a test server or test cloud you run it on?

@siyb @Clement134 @alibazlamit Maybe you can review?

Thank you